### PR TITLE
Get all students change continuation

### DIFF
--- a/ApiTestApp_Grupp3/ApiTestApp_Grupp3/Controllers/StudentsController.cs
+++ b/ApiTestApp_Grupp3/ApiTestApp_Grupp3/Controllers/StudentsController.cs
@@ -11,6 +11,7 @@ using System.Security.Cryptography.X509Certificates;
 using Microsoft.EntityFrameworkCore.Internal;
 using Newtonsoft.Json;
 using System.Security.Cryptography.Xml;
+using System.Net.Http.Headers;
 
 namespace ApiTestApp_Grupp3.Controllers
 {
@@ -62,12 +63,17 @@ namespace ApiTestApp_Grupp3.Controllers
                     foreach (var q in questionList)
                     {
                         var tempQuestion = await _context.Question.Where(x => x.QuestionId == q).Select(x => x).FirstOrDefaultAsync();
-                        
-                        tempQuestion.Answer = await _context.StudentQuestionAnswer.Where(x =>
-                            x.StudentId == student.StudentId && 
-                            x.TestId == test.TestId && 
+
+                        tempQuestion.QuestionAnswer = await _context.StudentQuestionAnswer.Where(x =>
+                            x.StudentId == student.StudentId &&
+                            x.TestId == test.TestId &&
                             x.QuestionId == tempQuestion.QuestionId)
-                            .Select(x => x.Answer)
+                            .Select(qa => new StudentQuestionAnswer {
+                                StudentId = qa.StudentId,
+                                TestId = qa.TestId,
+                                QuestionId = qa.QuestionId,
+                                Answer = qa.Answer,
+                                IsCorrect = qa.IsCorrect})
                             .FirstOrDefaultAsync();
                         
                         var jsonString = JsonConvert.SerializeObject(tempQuestion);

--- a/ApiTestApp_Grupp3/ApiTestApp_Grupp3/Models/Question.cs
+++ b/ApiTestApp_Grupp3/ApiTestApp_Grupp3/Models/Question.cs
@@ -37,8 +37,5 @@ namespace ApiTestApp_Grupp3.Models
         //instead of having an extra class on the client side and downloading the Courses as objects
         [NotMapped]
         public string CourseName { get; set; } 
-
-        [NotMapped]
-        public string Answer { get; set; } //Used when returning the question and answer of a specific student to the client
     }
 }

--- a/ApiTestApp_Grupp3/ApiTestApp_Grupp3/Models/Question.cs
+++ b/ApiTestApp_Grupp3/ApiTestApp_Grupp3/Models/Question.cs
@@ -37,5 +37,9 @@ namespace ApiTestApp_Grupp3.Models
         //instead of having an extra class on the client side and downloading the Courses as objects
         [NotMapped]
         public string CourseName { get; set; } 
+
+        [NotMapped]
+        public StudentQuestionAnswer QuestionAnswer { get; set; } //Object used for returning the answer & correction information for a specific student and test to the client.
+
     }
 }


### PR DESCRIPTION
Submitting this branch instead of the one before it. Missed a push and deleted som info. This has all been added here.

We now return a StudentQuestionAnswer object attached to a question for a specific student and test. instead of having properties for answers and iscorrect inside a question object